### PR TITLE
Redis-backed balance repository

### DIFF
--- a/banking-app/build.gradle
+++ b/banking-app/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation platform("org.axonframework:axon-bom:$axonVersion")
     implementation 'org.axonframework:axon-spring-boot-starter'
 
+    implementation "redis.clients:jedis:$jedisVersion"
+
     testImplementation platform("org.spockframework:spock-bom:$spockVersion")
     testImplementation "org.spockframework:spock-core"
     testImplementation "org.spockframework:spock-spring"
@@ -30,7 +32,7 @@ dependencies {
 }
 
 dockerCompose.isRequiredBy(test)
-dockerCompose.stopContainers = true // switch to 'false' for quick iteration during development
+dockerCompose.stopContainers = false // switch to 'false' for quick iteration during development
 
 test.doFirst {
     // expose dockerized Axon server's port to Spring configuration

--- a/banking-app/build.gradle
+++ b/banking-app/build.gradle
@@ -32,11 +32,13 @@ dependencies {
 }
 
 dockerCompose.isRequiredBy(test)
-dockerCompose.stopContainers = false // switch to 'false' for quick iteration during development
+dockerCompose.stopContainers = true // switch to 'false' for quick iteration during development
 
 test.doFirst {
     // expose dockerized Axon server's port to Spring configuration
     environment "AXON_PORT", dockerCompose.servicesInfos['axon-server'].tcpPorts[8124]
+    environment "REDIS_PORT", dockerCompose.servicesInfos['redis'].tcpPorts[6379]
+    environment "REDIS_HOST", "localhost"
 }
 
 test {

--- a/banking-app/src/main/java/io/dabrowa/whitebox/app/RedisBalanceRepository.java
+++ b/banking-app/src/main/java/io/dabrowa/whitebox/app/RedisBalanceRepository.java
@@ -1,0 +1,91 @@
+package io.dabrowa.whitebox.app;
+
+import io.dabrowa.whitebox.query.repository.BalanceRepository;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Transaction;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class RedisBalanceRepository implements BalanceRepository {
+
+    private static final String BALANCE_KEY_PREFIX = "account-balance";
+    private static final String NEGATIVE_BALANCE_ACCOUNTS_KEY = "negative-balances";
+
+    private final JedisPool jedisPool;
+
+    public RedisBalanceRepository(final JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    @Override
+    public Optional<BigDecimal> getBalance(String accountNumber) {
+        try (final Jedis jedis = jedisPool.getResource()) {
+            final var balance = jedis.get(key(accountNumber));
+            return Optional.ofNullable(balance)
+                    .map(BigDecimal::new);
+        }
+    }
+
+    @Override
+    public void debit(String accountNumber, BigDecimal value) {
+        try (final Jedis jedis = jedisPool.getResource()) {
+            final var key = key(accountNumber);
+
+            jedis.watch(key);
+            final var string = jedis.get(key);
+
+            BigDecimal newBalance;
+            if (string == null) {
+                newBalance = value.negate();
+            } else {
+                newBalance = new BigDecimal(string).subtract(value);
+            }
+            final Transaction transaction = jedis.multi();
+            transaction.set(key, newBalance.toString());
+            transaction.exec();
+
+            if (newBalance.compareTo(BigDecimal.ZERO) < 0) {
+                jedis.sadd(NEGATIVE_BALANCE_ACCOUNTS_KEY, accountNumber);
+            }
+        }
+    }
+
+    @Override
+    public void credit(String accountNumber, BigDecimal value) {
+        try (final Jedis jedis = jedisPool.getResource()) {
+            final var key = key(accountNumber);
+
+            jedis.watch(key);
+            final var string = jedis.get(key);
+
+            BigDecimal newBalance;
+            if (string == null) {
+                newBalance = value;
+            } else {
+                newBalance = new BigDecimal(string).add(value);
+            }
+            final Transaction transaction = jedis.multi();
+            transaction.set(key, newBalance.toString());
+            transaction.exec();
+
+            if (newBalance.compareTo(BigDecimal.ZERO) >= 0) {
+                jedis.srem(NEGATIVE_BALANCE_ACCOUNTS_KEY, accountNumber);
+            }
+        }
+    }
+
+    @Override
+    public Set<String> accountsWithNegativeBalance() {
+        try (final Jedis jedis = jedisPool.getResource()) {
+            return Set.copyOf(jedis.smembers(NEGATIVE_BALANCE_ACCOUNTS_KEY));
+        }
+    }
+
+    private String key(final String accountNumber) {
+        return "%s-%s".formatted(BALANCE_KEY_PREFIX, accountNumber);
+    }
+}

--- a/banking-app/src/main/java/io/dabrowa/whitebox/app/SpringAppConfiguration.java
+++ b/banking-app/src/main/java/io/dabrowa/whitebox/app/SpringAppConfiguration.java
@@ -6,16 +6,13 @@ import io.dabrowa.whitebox.query.projection.AccountBalanceProjector;
 import io.dabrowa.whitebox.query.projection.OverdraftProjector;
 import io.dabrowa.whitebox.query.projection.TransactionProjector;
 import io.dabrowa.whitebox.query.repository.*;
+import io.dabrowa.whitebox.query.repository.BalanceRepository.NonNegativeValuesRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPool;
 
 @Configuration
 public class SpringAppConfiguration {
-
-    @Bean
-    public BalanceRepository balanceRepository() {
-        return new InMemoryBalanceRepository();
-    }
 
     @Bean
     public OverdraftLimitRepository overdraftLimitRepository() {
@@ -51,5 +48,15 @@ public class SpringAppConfiguration {
     @Bean
     public TransactionProjector transactionProjector(final TransactionRepository transactionRepository) {
         return new TransactionProjector(transactionRepository);
+    }
+
+    @Bean
+    public JedisPool jedisPool() {
+        return new JedisPool("localhost", 6379);
+    }
+
+    @Bean
+    public BalanceRepository repository(final JedisPool jedisPool) {
+        return new NonNegativeValuesRepository(new RedisBalanceRepository(jedisPool));
     }
 }

--- a/banking-app/src/main/java/io/dabrowa/whitebox/app/SpringAppConfiguration.java
+++ b/banking-app/src/main/java/io/dabrowa/whitebox/app/SpringAppConfiguration.java
@@ -7,6 +7,7 @@ import io.dabrowa.whitebox.query.projection.OverdraftProjector;
 import io.dabrowa.whitebox.query.projection.TransactionProjector;
 import io.dabrowa.whitebox.query.repository.*;
 import io.dabrowa.whitebox.query.repository.BalanceRepository.NonNegativeValuesRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
@@ -51,8 +52,9 @@ public class SpringAppConfiguration {
     }
 
     @Bean
-    public JedisPool jedisPool() {
-        return new JedisPool("localhost", 6379);
+    public JedisPool jedisPool(@Value("${app.redis.host}") final String redisHost,
+                               @Value("${app.redis.port}") final int redisPort) {
+        return new JedisPool(redisHost, redisPort);
     }
 
     @Bean

--- a/banking-app/src/main/resources/application.yml
+++ b/banking-app/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+app:
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 axon:
   axonserver:
     servers: localhost:${AXON_PORT}

--- a/banking-app/src/test/groovy/io/dabrowa/whitebox/app/RedisBalanceRepositoryTest.groovy
+++ b/banking-app/src/test/groovy/io/dabrowa/whitebox/app/RedisBalanceRepositoryTest.groovy
@@ -1,0 +1,116 @@
+package io.dabrowa.whitebox.app
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import spock.lang.Specification
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+
+@SpringBootTest(webEnvironment = NONE, classes = [Main.class, SpringAppConfiguration.class])
+class RedisBalanceRepositoryTest extends Specification {
+
+    RedisBalanceRepository sut
+
+    @Autowired
+    TestAccountNumberProvider numberProvider
+
+    @Autowired
+    JedisPool jedisPool
+
+    def setup() {
+        try(Jedis jedis = jedisPool.resource) {
+            jedis.keys("*").each { jedis.del(it) }
+        }
+        sut = new RedisBalanceRepository(jedisPool)
+    }
+
+    def "returns empty response for account not in cache"() {
+        given:
+        def accountNumber = numberProvider.nextAvailable
+
+        expect:
+        sut.getBalance(accountNumber).empty
+    }
+
+    def "returns response for account in cache"() {
+        given:
+        def accountNumber = numberProvider.nextAvailable
+
+        when:
+        sut.credit(accountNumber, new BigDecimal("1245.965"))
+
+        then:
+        with(sut.getBalance(accountNumber)) {
+            it.present
+            it.get() == new BigDecimal("1245.965")
+        }
+    }
+
+    def "account transactions are correctly reflected in cache"() {
+        given:
+        def accountNumber = numberProvider.nextAvailable
+
+        when:
+        sut.credit(accountNumber, new BigDecimal("120.00"))
+        sut.credit(accountNumber, new BigDecimal("30.00"))
+        sut.debit(accountNumber, new BigDecimal("90.00"))
+
+        then:
+        with(sut.getBalance(accountNumber)) {
+            it.present
+            it.get() == new BigDecimal("60")
+        }
+
+        when:
+        sut.debit(accountNumber, new BigDecimal("15.15"))
+        sut.credit(accountNumber, new BigDecimal("2.88"))
+
+        then:
+        with(sut.getBalance(accountNumber)) {
+            it.present
+            it.get() == new BigDecimal("47.73")
+        }
+    }
+
+    def "accounts with negative balances are correctly identified"() {
+        given:
+        def accountNumber = numberProvider.nextAvailable
+        def otherAccountNumber = numberProvider.nextAvailable
+
+        when: 'accounts have positive balances'
+        sut.credit(accountNumber, new BigDecimal("120.00"))
+        sut.credit(otherAccountNumber, new BigDecimal("30.00"))
+
+        then: 'response is empty'
+        sut.accountsWithNegativeBalance().empty
+
+        when: 'one account goes below zero'
+        sut.debit(otherAccountNumber, new BigDecimal("130.00"))
+
+        then: 'it is returned in response'
+        sut.accountsWithNegativeBalance().size() == 1
+        sut.accountsWithNegativeBalance() == [otherAccountNumber] as Set
+
+        when: 'second account goes below zero'
+        sut.debit(accountNumber, new BigDecimal("220.00"))
+
+        then: 'they are both on the result list'
+        sut.accountsWithNegativeBalance().size() == 2
+        sut.accountsWithNegativeBalance() == [accountNumber, otherAccountNumber] as Set
+
+        when: 'account pays the debt'
+        sut.credit(otherAccountNumber, new BigDecimal("1000.00"))
+
+        then: 'it is no longer on the offender list'
+        sut.accountsWithNegativeBalance().size() == 1
+        sut.accountsWithNegativeBalance() == [accountNumber] as Set
+
+        when: 'second account pays the debt'
+        sut.credit(accountNumber, new BigDecimal("1000.00"))
+
+        then: 'it too is no longer on the offender list'
+        sut.accountsWithNegativeBalance().empty
+    }
+}

--- a/banking-app/src/test/java/io/dabrowa/whitebox/app/SpringTestConfiguration.java
+++ b/banking-app/src/test/java/io/dabrowa/whitebox/app/SpringTestConfiguration.java
@@ -1,5 +1,6 @@
 package io.dabrowa.whitebox.app;
 
+import io.dabrowa.whitebox.query.repository.InMemoryBalanceRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -11,5 +12,11 @@ public class SpringTestConfiguration {
     @Primary
     public TestAccountNumberProvider accountNumberRegistry() {
         return new TestAccountNumberProvider();
+    }
+
+    @Bean
+    @Primary
+    public InMemoryBalanceRepository inMemoryBalanceRepository() {
+        return new InMemoryBalanceRepository();
     }
 }

--- a/banking-query/src/main/java/io/dabrowa/whitebox/query/repository/BalanceRepository.java
+++ b/banking-query/src/main/java/io/dabrowa/whitebox/query/repository/BalanceRepository.java
@@ -1,8 +1,8 @@
 package io.dabrowa.whitebox.query.repository;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface BalanceRepository {
     Optional<BigDecimal> getBalance(String accountNumber);
@@ -11,5 +11,47 @@ public interface BalanceRepository {
 
     void credit(String accountNumber, BigDecimal value);
 
-    List<String> accountsWithNegativeBalance();
+    Set<String> accountsWithNegativeBalance();
+
+    /**
+     * Decorator pattern-style class encapsulating logic potentially useful
+     * for all implementations: only allow positive values for credit
+     * and debits, as they should always be positive and their type
+     * is determined by context (credit/debit operation)
+     */
+    class NonNegativeValuesRepository implements BalanceRepository {
+        private final BalanceRepository delegate;
+
+        public NonNegativeValuesRepository(final BalanceRepository delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Optional<BigDecimal> getBalance(final String accountNumber) {
+            return delegate.getBalance(accountNumber);
+        }
+
+        @Override
+        public void debit(final String accountNumber, final BigDecimal value) {
+            ensureNonNegative(value);
+            delegate.debit(accountNumber, value);
+        }
+
+        @Override
+        public void credit(final String accountNumber, final BigDecimal value) {
+            ensureNonNegative(value);
+            delegate.credit(accountNumber, value);
+        }
+
+        @Override
+        public Set<String> accountsWithNegativeBalance() {
+            return delegate.accountsWithNegativeBalance();
+        }
+
+        private void ensureNonNegative(BigDecimal value) {
+            if(value.compareTo(BigDecimal.ZERO) < 0) {
+                throw new IllegalArgumentException("Value cannot be negative");
+            }
+        }
+    }
 }

--- a/banking-query/src/main/java/io/dabrowa/whitebox/query/repository/InMemoryBalanceRepository.java
+++ b/banking-query/src/main/java/io/dabrowa/whitebox/query/repository/InMemoryBalanceRepository.java
@@ -4,12 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class InMemoryBalanceRepository implements BalanceRepository {
     private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryBalanceRepository.class);
@@ -49,11 +49,11 @@ public class InMemoryBalanceRepository implements BalanceRepository {
     }
 
     @Override
-    public List<String> accountsWithNegativeBalance() {
+    public Set<String> accountsWithNegativeBalance() {
         return accountBalances.entrySet().stream()
                 .filter(entry -> entry.getValue().compareTo(BigDecimal.ZERO) < 0)
                 .map(Map.Entry::getKey)
-                .collect(toList());
+                .collect(toSet());
     }
 
     public void cleanup() {

--- a/banking-query/src/test/groovy/io/dabrowa/whitebox/query/repository/NonNegativeValuesRepositoryTest.groovy
+++ b/banking-query/src/test/groovy/io/dabrowa/whitebox/query/repository/NonNegativeValuesRepositoryTest.groovy
@@ -1,0 +1,55 @@
+package io.dabrowa.whitebox.query.repository
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NonNegativeValuesRepositoryTest extends Specification {
+    def delegate = Mock(BalanceRepository)
+    def sut = new BalanceRepository.NonNegativeValuesRepository(delegate)
+
+    def accountNumber = "1234"
+
+    def "credit value cannot be negative"() {
+        when:
+        sut.credit(accountNumber, new BigDecimal("-1.1"))
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Value cannot be negative"
+    }
+
+    @Unroll
+    def "credit value can be non-negative"() {
+        when:
+        sut.credit(accountNumber, new BigDecimal(value))
+
+        then:
+        noExceptionThrown()
+        1 * delegate.credit(accountNumber, new BigDecimal(value))
+
+        where:
+        value << ["0.0000", "123"]
+    }
+
+    def "debit value cannot be negative"() {
+        when:
+        sut.debit(accountNumber, new BigDecimal("-1.1"))
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Value cannot be negative"
+    }
+
+    @Unroll
+    def "debit value can be non-negative"() {
+        when:
+        sut.debit(accountNumber, new BigDecimal(value))
+
+        then:
+        noExceptionThrown()
+        1 * delegate.debit(accountNumber, new BigDecimal(value))
+
+        where:
+        value << ["0.0000", "123"]
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ subprojects {
         spockVersion = '2.4-M1-groovy-4.0'
         gradleDockerComposeVersion = '0.16.11'
         awaitilityVersion = '4.2.0'
+        jedisVersion = '4.3.1'
     }
 
     dependencyManagement {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
   redis:
     image: "redis:7.0.8"
     ports:
-      - "6379:6379"
+      - "6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     ports:
       - "8024"
       - "8124"
+  redis:
+    image: "redis:7.0.8"
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
Materializing balances in Redis.
Since it's read-then-write operation, it's guarded by simple check: Redis watch is set on the account balance's key to detect concurrent modification and fail if it occurrs. This is not a production-grade solution, but should suffice for demonstrative purposes.